### PR TITLE
Allow for packages to be stored in a sub-directory

### DIFF
--- a/stable/bundle.pony
+++ b/stable/bundle.pony
@@ -6,10 +6,10 @@ class box Bundle
   let log: Log
   let path: FilePath
   let json: JsonDoc = JsonDoc
-  
+
   new create(path': FilePath, log': Log = LogNone)? =>
     path = path'; log = log'
-    
+
     let file = OpenFile(path.join("bundle.json")) as File
     let content: String = file.read_string(file.size())
     try json.parse(content) else
@@ -18,12 +18,12 @@ class box Bundle
                             + " : " + err_message)
       error
     end
-  
+
   fun deps(): Iterator[BundleDep] =>
     let deps_array = try (json.data as JsonObject).data("deps") as JsonArray
                      else JsonArray
                      end
-    
+
     object is Iterator[BundleDep]
       let bundle: Bundle = this
       let inner: Iterator[JsonType] = deps_array.data.values()
@@ -31,23 +31,23 @@ class box Bundle
       fun ref next(): BundleDep^? =>
         BundleDepFactory(bundle, inner.next() as JsonObject)
     end
-  
+
   fun fetch() =>
     for dep in deps() do
       try dep.fetch() end
     end
     for dep in deps() do
       // TODO: detect and prevent infinite recursion here.
-      try Bundle(FilePath(path, dep.path()), log).fetch() end
+      try Bundle(FilePath(path, dep.root_path()), log).fetch() end
     end
-  
+
   fun paths(): Array[String] val =>
     let out = recover trn Array[String] end
     for dep in deps() do
-      out.push(dep.path())
+      out.push(dep.packages_path())
     end
     for dep in deps() do
       // TODO: detect and prevent infinite recursion here.
-      try out.append(Bundle(FilePath(path, dep.path()), log).paths()) end
+      try out.append(Bundle(FilePath(path, dep.packages_path()), log).paths()) end
     end
     out

--- a/stable/bundle_dep.pony
+++ b/stable/bundle_dep.pony
@@ -3,7 +3,8 @@ use "json"
 use "debug"
 
 interface BundleDep
-  fun path(): String
+  fun root_path(): String
+  fun packages_path(): String
   fun ref fetch()?
 
 primitive BundleDepFactory
@@ -17,19 +18,24 @@ class BundleDepGitHub
   let bundle: Bundle
   let info: JsonObject
   let repo: String
+  let subdir: String
   new create(b: Bundle, i: JsonObject)? =>
     bundle = b; info = i
     repo = try info.data("repo") as String
            else bundle.log("No 'repo' key in dep: " + info.string()); error
            end
-  
-  fun path(): String => ".deps/" + repo
+    subdir = try info.data("subdir") as String
+             else ""
+             end
+
+  fun root_path(): String => ".deps/" + repo
+  fun packages_path(): String => root_path() + "/" + subdir
   fun url(): String => "https://github.com/" + repo
-  
+
   fun ref fetch()? =>
-    try Shell("test -d "+path())
-      Shell("git -C "+path()+" pull")
+    try Shell("test -d "+root_path())
+      Shell("git -C "+root_path()+" pull")
     else
-      Shell("mkdir -p "+path())
-      Shell("git clone "+url()+" "+path())
+      Shell("mkdir -p "+root_path())
+      Shell("git clone "+url()+" "+root_path())
     end


### PR DESCRIPTION
By default, pony-stable expects your dependency to be
stored in the top level of its repo. For example, if
you are looking for `inspect`, it expects there to be
a `inspect` directory at the top level of the GitHub
repository. Not all Pony libraries currently share that
layout.

Until we have a package manager that can unify library
directory layout, this commit add 'subdir' as a dependency
option. For example:

```
{
  "deps": [
    { "type": "github", "repo": "aturley/osc-pony", "subdir": "src/" }
  ]
}
```

which will look for any dependencies (in this case osc-pony), not
in the top level of the 'aturley/osc-pony' repo but rather in
'aturley/osc-pony/src'.
