### PR TITLE
Fix silent and deadly error

### DIFF
--- a/stable/bundle.pony
+++ b/stable/bundle.pony
@@ -20,16 +20,17 @@ class box Bundle
     end
 
   fun deps(): Iterator[BundleDep] =>
-    let deps_array = try (json.data as JsonObject).data("deps") as JsonArray
-                     else JsonArray
-                     end
+    let deps_array =
+      try (json.data as JsonObject box).data("deps") as JsonArray box
+      else JsonArray
+      end
 
     object is Iterator[BundleDep]
       let bundle: Bundle = this
-      let inner: Iterator[JsonType] = deps_array.data.values()
+      let inner: Iterator[JsonType box] = deps_array.data.values()
       fun ref has_next(): Bool    => inner.has_next()
       fun ref next(): BundleDep^? =>
-        BundleDepFactory(bundle, inner.next() as JsonObject)
+        BundleDepFactory(bundle, inner.next() as JsonObject box)
     end
 
   fun fetch() =>

--- a/stable/bundle_dep.pony
+++ b/stable/bundle_dep.pony
@@ -8,7 +8,7 @@ interface BundleDep
   fun ref fetch()?
 
 primitive BundleDepFactory
-  fun apply(bundle: Bundle, dep: JsonObject): BundleDep? =>
+  fun apply(bundle: Bundle, dep: JsonObject box): BundleDep? =>
     match dep.data("type")
     | "github" => BundleDepGitHub(bundle, dep)
     else error
@@ -16,10 +16,10 @@ primitive BundleDepFactory
 
 class BundleDepGitHub
   let bundle: Bundle
-  let info: JsonObject
+  let info: JsonObject box
   let repo: String
   let subdir: String
-  new create(b: Bundle, i: JsonObject)? =>
+  new create(b: Bundle, i: JsonObject box)? =>
     bundle = b; info = i
     repo = try info.data("repo") as String
            else bundle.log("No 'repo' key in dep: " + info.string()); error
@@ -39,3 +39,4 @@ class BundleDepGitHub
       Shell("mkdir -p "+root_path())
       Shell("git clone "+url()+" "+root_path())
     end
+


### PR DESCRIPTION
Without this fix, with recent fixes to the ponyc compiler,
nothing will get run because json.data is not a JsonObject,
its a JsonObject box.

According to Sylvan this always should have been the case but
wasn't surfaced until another bug was fixed.
