### PR TITLE
Fix silent and deadly error

### DIFF
--- a/stable/bundle.pony
+++ b/stable/bundle.pony
@@ -6,10 +6,10 @@ class box Bundle
   let log: Log
   let path: FilePath
   let json: JsonDoc = JsonDoc
-  
+
   new create(path': FilePath, log': Log = LogNone)? =>
     path = path'; log = log'
-    
+
     let file = OpenFile(path.join("bundle.json")) as File
     let content: String = file.read_string(file.size())
     try json.parse(content) else
@@ -18,20 +18,20 @@ class box Bundle
                             + " : " + err_message)
       error
     end
-  
+
   fun deps(): Iterator[BundleDep] =>
-    let deps_array = try (json.data as JsonObject).data("deps") as JsonArray
+    let deps_array = try (json.data as JsonObject box).data("deps") as JsonArray box
                      else JsonArray
                      end
-    
+
     object is Iterator[BundleDep]
       let bundle: Bundle = this
-      let inner: Iterator[JsonType] = deps_array.data.values()
+      let inner: Iterator[JsonType box] = deps_array.data.values()
       fun ref has_next(): Bool    => inner.has_next()
       fun ref next(): BundleDep^? =>
-        BundleDepFactory(bundle, inner.next() as JsonObject)
+        BundleDepFactory(bundle, inner.next() as JsonObject box)
     end
-  
+
   fun fetch() =>
     for dep in deps() do
       try dep.fetch() end
@@ -40,7 +40,7 @@ class box Bundle
       // TODO: detect and prevent infinite recursion here.
       try Bundle(FilePath(path, dep.root_path()), log).fetch() end
     end
-  
+
   fun paths(): Array[String] val =>
     let out = recover trn Array[String] end
     for dep in deps() do

--- a/stable/bundle_dep.pony
+++ b/stable/bundle_dep.pony
@@ -8,7 +8,7 @@ interface BundleDep
   fun ref fetch()?
 
 primitive BundleDepFactory
-  fun apply(bundle: Bundle, dep: JsonObject): BundleDep? =>
+  fun apply(bundle: Bundle, dep: JsonObject box): BundleDep? =>
     match dep.data("type")
     | "github" => BundleDepGitHub(bundle, dep)
     else error
@@ -16,10 +16,10 @@ primitive BundleDepFactory
 
 class BundleDepGitHub
   let bundle: Bundle
-  let info: JsonObject
+  let info: JsonObject box
   let repo: String
   let subdir: String
-  new create(b: Bundle, i: JsonObject)? =>
+  new create(b: Bundle, i: JsonObject box)? =>
     bundle = b
     info   = i
     repo   = try info.data("repo") as String
@@ -28,11 +28,11 @@ class BundleDepGitHub
     subdir = try info.data("subdir") as String
              else ""
              end
-  
+
   fun root_path(): String => ".deps/" + repo
   fun packages_path(): String => root_path() + "/" + subdir
   fun url(): String => "https://github.com/" + repo
-  
+
   fun ref fetch()? =>
     try Shell("test -d "+root_path())
       Shell("git -C "+root_path()+" pull")


### PR DESCRIPTION
Without this fix, with recent fixes to the ponyc compiler,
nothing will get run because json.data is not a JsonObject,
its a JsonObject box.

According to Sylvan this always should have been the case but
wasn't surfaced until another bug was fixed.
