### PR TITLE
Enhancement to work for all pony projects

### DIFF
--- a/stable/main.pony
+++ b/stable/main.pony
@@ -29,21 +29,26 @@ actor Main
   
   fun _load_bundle(): Bundle? =>
     try Bundle(FilePath(env.root as AmbientAuth, "."), log)
-    else log("Failed to load bundle in current working directory."); error
+    else log("No bundle in current working directory."); error
     end
   
   fun command("fetch", _) =>
     try _load_bundle().fetch() end
   
   fun command("env", rest: Array[String] box) =>
-    try let bundle = _load_bundle()
-      var ponypath = recover trn String end
+    let ponypath = try let bundle = _load_bundle()
+      var ponypath' = recover trn String end
       let iter = bundle.paths().values()
       for path in iter do
-        ponypath.append(path)
-        if iter.has_next() then ponypath.push(':') end
+        ponypath'.append(path)
+        if iter.has_next() then ponypath'.push(':') end
       end
       
+      ponypath'
+    else
+      ""
+    end
+    try
       Shell.from_array(
         ["env", "PONYPATH="+ponypath].append(rest), env~exitcode()
       )


### PR DESCRIPTION
This PR makes it so that `stable` works for all pony projects even if a `bundle.json` doesn't exist. This was primarily driven by our desire to use `stable` as part of our build toolchain where some projects will have a `bundle.json` while others will not. Without this change, if a `bundle.json` didn't exist, `stable` wouldn't run the commands requested.
- `stable` didn't work properly if no bundle.json existed.
- Enhances `stable` so the appropriate command runs even if no
  bundle.json exists.
