### PR TITLE
Fix `stable fetch` bug when using tags

### DIFF
--- a/stable/bundle_dep.pony
+++ b/stable/bundle_dep.pony
@@ -39,7 +39,7 @@ class BundleDepGitHub
 
   fun ref fetch()? =>
     try Shell("test -d "+root_path())
-      Shell("git -C "+root_path()+" pull")
+      Shell("git -C "+root_path()+" pull "+url())
     else
       Shell("mkdir -p "+root_path())
       Shell("git clone "+url()+" "+root_path())


### PR DESCRIPTION
The bug was that when the `bundle.json` specified a `tag` all
invocations of `stable fetch` after the first one would fail due
to the git checkout being in a `detached HEAD` state. This commit
fixes the bug.
