### PR TITLE
Look for bundle.json in ancestor directories

### DIFF
--- a/stable/dep.pony
+++ b/stable/dep.pony
@@ -1,5 +1,6 @@
 
 use "json"
+use "files"
 
 interface DepAny
   fun root_path(): String
@@ -34,8 +35,8 @@ class DepGitHub
               else None
               end
   
-  fun root_path(): String => ".deps/" + repo
-  fun packages_path(): String => root_path() + "/" + subdir
+  fun root_path(): String => Path.join(bundle.path.path, Path.join(".deps", repo))
+  fun packages_path(): String => Path.join(root_path(), subdir)
   fun url(): String => "https://github.com/" + repo
   
   fun ref fetch()? =>
@@ -73,7 +74,7 @@ class DepLocalGit
                    end
     bundle.log(package_name)
   
-  fun root_path(): String => ".deps/"+package_name
+  fun root_path(): String => Path.join(bundle.path.path, Path.join(".deps", package_name))
   fun packages_path(): String => root_path()
   
   fun ref fetch()? =>

--- a/stable/main.pony
+++ b/stable/main.pony
@@ -30,8 +30,20 @@ actor Main
     ""] end)
   
   fun _load_bundle(create_on_missing: Bool = false): Bundle? =>
-    try Bundle(FilePath(env.root as AmbientAuth, "."), log, create_on_missing)
-    else log("No bundle in current working directory."); error
+    let cwd = Path.cwd()
+    var path = cwd
+    while path.size() > 0 do
+      try
+        return Bundle(FilePath(env.root as AmbientAuth, path), log, false)
+      else
+        path = Path.split(path)._1
+      end
+    end
+    if create_on_missing then
+      Bundle(FilePath(env.root as AmbientAuth, cwd), log, true)
+    else
+      log("No bundle.json in current working directory or ancestors.")
+      error
     end
   
   fun command("fetch", _) =>


### PR DESCRIPTION
This allows using stable to compile sub-packages within a project, where dependencies are defined at a root level.

`.deps` is created in the same directory as `bundle.json`, even when running `stable fetch` from a subdirectory.

`stable env` now populates `$PONYPATH` with absolute paths.
