### PR TITLE
Fix invalid separator in PONYPATH for windows.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the Pony compiler and standard library will be documented
 
 ### Fixed
 
-
+- Fix invalid separator in PONYPATH for Windows. ([PR #32](https://github.com/ponylang/pony-stable/pull/32))
 
 ### Added
 

--- a/stable/main.pony
+++ b/stable/main.pony
@@ -57,9 +57,10 @@ actor Main
         let bundle = _load_bundle()?
         let ponypath' = recover trn String end
         let iter = bundle.paths().values()
+        let sep = Path.list_sep()(0)?
         for path in iter do
           ponypath'.append(path)
-          if iter.has_next() then ponypath'.push(':') end
+          if iter.has_next() then ponypath'.push(sep) end
         end
 
         ponypath'


### PR DESCRIPTION
When it has multiple dependencies, PONYPATH end up like

`PONYPATH=C:\.deps\foo:C:\.deps\bar`

But PONYPATH should be separated by semicolon on windows.
