### PR TITLE
Add `version` command line option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 build
+# generated
+stable/version.pony

--- a/make.bat
+++ b/make.bat
@@ -27,6 +27,16 @@ if errorlevel 1 goto noponyc
 :build
 if not exist "%BUILDDIR%" mkdir "%BUILDDIR%""
 echo Compiling: ponyc stable -o %BUILDDIR% %DEBUG%
+set /p VERSION=<VERSION
+if exist ".git" for /f %%i in ('git rev-parse --short HEAD') do set "VERSION=%VERSION%-%%i [%CONFIG%]"
+if not exist ".git" set "VERSION=%VERSION% [%CONFIG%]"
+setlocal enableextensions disabledelayedexpansion
+for /f "delims=" %%i in ('type stable\version.pony.in ^& break ^> stable\version.pony') do (
+  set "line=%%i"
+  setlocal enabledelayedexpansion
+  >>stable\version.pony echo(!line:%%%%VERSION%%%%=%VERSION%!
+  endlocal
+)
 ponyc stable -o %BUILDDIR% %DEBUG%
 goto done
 

--- a/stable/main.pony
+++ b/stable/main.pony
@@ -20,13 +20,14 @@ actor Main
           "    Invoke in a working directory containing a bundle.json."
           ""
           "Commands:"
-          "    help  - Print this message"
-          "    fetch - Fetch/update the deps for this bundle"
-          "    env   - Execute the following shell command inside an environment"
-          "            with PONYPATH set to include deps directories. For example,"
-          "            `stable env ponyc myproject`"
-          "    add   - Add a new dependency. For exemple,"
-          "            `stable add github jemc/pony-inspect"
+          "    help    - Print this message"
+          "    version - Print version information"
+          "    fetch   - Fetch/update the deps for this bundle"
+          "    env     - Execute the following shell command inside an environment"
+          "              with PONYPATH set to include deps directories. For example,"
+          "              `stable env ponyc myproject`"
+          "    add     - Add a new dependency. For exemple,"
+          "              `stable add github jemc/pony-inspect"
           ""
         ]
       end)
@@ -92,6 +93,9 @@ actor Main
       bundle.add_dep(added_json)?
       bundle.fetch()
     end
+
+  fun command("version", rest: Array[String] box) =>
+    env.out.print(Version())
 
   fun command(s: String, rest: Array[String] box) =>
     _print_usage()

--- a/stable/version.pony.in
+++ b/stable/version.pony.in
@@ -1,0 +1,3 @@
+primitive Version
+  fun apply() : String =>
+    "%%VERSION%%"


### PR DESCRIPTION
I couldn't find a way to pass any defines to ponyc that go beyond flags
(ifdef and -D=foo don't seem to work with variables?) -- so I ended up
generating a stable/version.pony.

Issue #41 left it open how exactly this should look. This change only
outputs the version of stable,

    $ stable version
    0.1.0-af246fe [release]

and nothing related to the ponyc (and, transitively, LLVM) version used
-- does it make sense to include that? I wasn't convinced.

Signed-off-by: Stephan Renatus <srenatus@chef.io>