### PR TITLE
Add `arch=` option to `make` and set `arch=x86-64` for packaging

### DIFF
--- a/.travis_script.bash
+++ b/.travis_script.bash
@@ -35,7 +35,7 @@ pony-stable-build-packages(){
   PACKAGE_ITERATION="${TRAVIS_BUILD_NUMBER}.$(git rev-parse --short --verify 'HEAD^{commit}')"
 
   echo "Building ponyc packages for deployment..."
-  make package_name="pony-stable" package_base_version="$(cat VERSION)" package_iteration="${PACKAGE_ITERATION}" deploy
+  make arch=x86-64 package_name="pony-stable" package_base_version="$(cat VERSION)" package_iteration="${PACKAGE_ITERATION}" deploy
 }
 
 if [[ "$TRAVIS_BRANCH" == "release" && "$TRAVIS_PULL_REQUEST" == "false" ]]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 prefix ?= /usr/local
 destdir ?= ${prefix}
 config ?= release
+arch ?=
 
 BUILD_DIR ?= build/$(config)
 SRC_DIR ?= stable
@@ -18,6 +19,10 @@ else
 	PONYC = ponyc --debug
 endif
 
+ifneq ($(arch),)
+  arch_arg := --cpu $(arch)
+endif
+
 ifneq ($(wildcard .git),)
   tag := $(shell cat VERSION)-$(shell git rev-parse --short HEAD)
 else
@@ -33,7 +38,7 @@ GEN_FILES = $(patsubst %.pony.in, %.pony, $(GEN_FILES_IN))
 	sed s/%%VERSION%%/$(VERSION)/ $< > $@
 
 $(binary): $(GEN_FILES) $(SOURCE_FILES) | $(BUILD_DIR)
-	${PONYC} $(SRC_DIR) -o ${BUILD_DIR}
+	${PONYC} $(arch_arg) $(SRC_DIR) -o ${BUILD_DIR}
 
 install: $(binary)
 	mkdir -p $(prefix)/bin


### PR DESCRIPTION
Setting `arch=x86-64` forces `ponyc` to generate instructions for
a generic x86-64 CPU instead of for whatever CPU `ponyc` is being
run on.

This is necessary to prevent `Illegal instruction (core dumped)`
errors from occurring as experienced in Travis CI builds of
Wallaroo (and also by anyone with an older CPU). One such example
is at: https://travis-ci.org/WallarooLabs/wallaroo/builds/287214722

----------------------------

NOTE: I named the option `arch` to match up with what is used in the `ponyc` `make` command but we're controlling the `--cpu` argument to `ponyc`. It might be better to rename the argument to `cpu` for clarity.