### PR TITLE
Use user friendly version numbers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,9 +65,9 @@ package = build/$(package_name)-$(package_version)
 # Note: linux only
 define EXPAND_DEPLOY
 deploy: test
-	$(SILENT)bash .bintray.bash debian "$(package_version)" "$(package_name)"
-	$(SILENT)bash .bintray.bash rpm    "$(package_version)" "$(package_name)"
-	$(SILENT)bash .bintray.bash source "$(package_version)" "$(package_name)"
+	$(SILENT)bash .bintray.bash debian "$(package_base_version)" "$(package_name)"
+	$(SILENT)bash .bintray.bash rpm    "$(package_base_version)" "$(package_name)"
+	$(SILENT)bash .bintray.bash source "$(package_base_version)" "$(package_name)"
 	$(SILENT)rm -rf build/bin
 	@mkdir -p build/bin
 	@mkdir -p $(package)/usr/bin


### PR DESCRIPTION
I've opened a PR against ponyc to make the same change as this. Here's
the explanation from there:

Right now, as an artifact of when we did uploads to bintray for every
commit to master, we have version numbers that look like:

0.20.0-4003.0b2a2d2

This is needed if we are doing multiple releases per version like we
once were with the commits to master but, it isn't otherwise.

It's hostile in fact to doing an install.

If I wanted to install ponyc version 0.20.0 from bintray I can't do:

apt-get install ponyc=0.20.0

I have to look up the specific release that corresponds to 0.20.0 and
do:

apt-get install ponyc=0.20.0-4003.0b2a2d2

I noticed this as part of setting up Wallaroo Labs CI to be able to test
against multiple versions of Ponyc. Definitely unfriendly. Additionally,
it makes it harder on software that wants to give a specific version of
ponyc it works with.

You have to go look up the "long name" rather than just saying "0.20.0".

This commit switches releases to use the short name "0.20.0". If we ever
start doing uploads for every commit to master to something like
appveyor, we would want another Makefile target that uses
"$(package_base_version)" like the current deploy target does.