### PR TITLE
Remove case functions.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -53,6 +53,7 @@ install:
       {
         $latest_url = $res.GetResponseHeader("Location")
         $latest_ver = $latest_url.Substring($latest_url.LastIndexOf("/") + 1)
+        $latest_ver = $latest_ver.Substring(0, $latest_ver.LastIndexOf("-"))
         $download_url = "https://bintray.com/pony-language/ponyc-win/download_file?file_path=" + $latest_ver + "-win64.zip"
         Invoke-WebRequest -Uri $download_url -OutFile ponyc.zip
         Expand-Archive "ponyc.zip" -DestinationPath "."

--- a/stable/main.pony
+++ b/stable/main.pony
@@ -49,10 +49,10 @@ actor Main
       error
     end
 
-  fun command("fetch", _) =>
+  fun command_fetch() =>
     try _load_bundle()?.fetch() end
 
-  fun command("env", rest: Array[String] box) =>
+  fun command_env(rest: Array[String] box) =>
     let ponypath =
       try
         let bundle = _load_bundle()?
@@ -86,7 +86,7 @@ actor Main
       end
     end
 
-  fun command("add", rest: Array[String] box) =>
+  fun command_add(rest: Array[String] box) =>
     try
       let bundle = _load_bundle(true)?
       let added_json = Add(rest, log)?
@@ -94,8 +94,19 @@ actor Main
       bundle.fetch()
     end
 
-  fun command("version", rest: Array[String] box) =>
+  fun command_version(rest: Array[String] box) =>
     env.out.print(Version())
 
   fun command(s: String, rest: Array[String] box) =>
-    _print_usage()
+    match s
+    | "fetch" =>
+      command_fetch()
+    | "env" =>
+      command_env(rest)
+    | "add" =>
+      command_add(rest)
+    | "version" =>
+      command_version(rest)
+    else
+      _print_usage()
+    end


### PR DESCRIPTION
The Pony compiler has recently had case function support removed (https://github.com/ponylang/ponyc/commit/9f5298577f812dcf429323fec39c03c9b2ba5c69).  This change changes case functions in `main.pony` to use different names to keep pony-stable building with the latest compiler.