### PR TITLE
Update usage of Env.exitcode to be compatible with ponyc 0.22.x

### DIFF
--- a/stable/main.pony
+++ b/stable/main.pony
@@ -79,10 +79,10 @@ actor Main
           cmd.append(arg)
         end
         cmd.append("\"")
-        Shell(consume cmd, env~exitcode())?
+        Shell(consume cmd, env.exitcode)?
       else
         Shell.from_array(
-          ["env"; "PONYPATH=" + ponypath] .> append(rest), env~exitcode())?
+          ["env"; "PONYPATH=" + ponypath] .> append(rest), env.exitcode)?
       end
     end
 

--- a/stable/shell.pony
+++ b/stable/shell.pony
@@ -1,7 +1,7 @@
 use @system[I32](command: Pointer[U8] tag)
 
-interface _ExitCodeFn
-  fun ref apply(code: I32)
+interface val _ExitCodeFn
+  fun apply(code: I32)
 
 // TODO: Remove Shell hack in favor of cap-based implementations of actions.
 primitive Shell


### PR DESCRIPTION
After merging https://github.com/ponylang/ponyc/pull/2617 to ponyc, pony-stable needs this update to be compatible with latest ponyc master.