### PR TITLE
Document CLI and bundle.json

### DIFF
--- a/doc/cli/stable-add.md
+++ b/doc/cli/stable-add.md
@@ -4,6 +4,7 @@ stable-add(1) -- add a dependency
 ## SYNOPSIS
 
     stable add github <url-path> [options]
+    stable add gitlab <url-path> [options]
     stable add local-git <path> [options]
     stable add local <path>
     stable add
@@ -26,8 +27,23 @@ Download a github repository into your project.
   * `-d` _directory_ , `--subdir` _directory_:
   Fetch only a subdirectory of the project
 
-      stable add github jemc/pony-inspect
+  ```
+  stable add github jemc/pony-inspect
+  ```
+  
+### gitlab
 
+Download a gitlab repository into your project.
+
+  * `-t` _git-tag_, `--tag` _git-tag_:
+  Specify a tag from the source repository
+  * `-d` _directory_ , `--subdir` _directory_:
+  Fetch only a subdirectory of the project
+
+  ```
+  stable add gitlab org/repo
+  ```
+  
 ### local-git
 
 Copy a local git repository into your project.

--- a/doc/cli/stable-add.md
+++ b/doc/cli/stable-add.md
@@ -1,0 +1,46 @@
+stable-add(1) -- add a dependency
+=================================
+
+## SYNOPSIS
+
+    stable add github <url-path> [options]
+    stable add local-git <path> [options]
+    stable add local <path>
+    stable add
+
+## DESCRIPTION
+
+This command adds a dependency to the local `bundle.json` and fetches
+the added repository. There are three available sources of dependencies:
+github download, copying from a local git repository, and a less
+featureful copying from a local directory without using git.
+
+## SOURCES
+
+### github
+
+Download a github repository into your project.
+
+  * `-t` _git-tag_, `--tag` _git-tag_:
+  Specify a tag from the source repository
+  * `-d` _directory_ , `--subdir` _directory_:
+  Fetch only a subdirectory of the project
+
+      stable add github jemc/pony-inspect
+
+### local-git
+
+Copy a local git repository into your project.
+
+  * `-t` _git-tag_, `--tag` _git-tag_:
+  Specify a tag from the source repository
+
+### local
+
+Copy a local directory into your project.
+
+## EXAMPLES
+
+    stable add github jemc/pony-inspect
+    stable add local-git ../other-project -t v1.1
+    stable add local ../gitless-project

--- a/doc/cli/stable-env.md
+++ b/doc/cli/stable-env.md
@@ -1,0 +1,16 @@
+stable-env(1) -- run a command in a stable environment
+======================================================
+
+## SYNOPSIS
+
+    stable env <command>
+
+## DESCRIPTION
+
+This command allows you to run another command with the environment
+needed for `ponyc` to use your stable-managed dependencies. Use
+this command with `ponyc` to build your project.
+
+## EXAMPLES
+
+    stable env ponyc

--- a/doc/cli/stable-fetch.md
+++ b/doc/cli/stable-fetch.md
@@ -1,0 +1,11 @@
+stable-fetch(1) -- update dependencies
+======================================
+
+## SYNOPSIS
+
+    stable fetch
+
+## DESCRIPTION
+
+Updates the local .deps directory with the most recent
+content from the source repositories.

--- a/doc/cli/stable.md
+++ b/doc/cli/stable.md
@@ -1,0 +1,40 @@
+stable(1) -- pony dependency manager
+====================================
+
+## SYNOPSIS
+
+    stable <command> [args]
+
+## DESCRIPTION
+
+stable is a simple dependency manager for pony. It fetches
+dependencies from your local filesystem and remote sources
+and provides a build environment that directs `ponyc` to use
+those fetched dependencies.
+
+`stable help` provides a list of available commands.
+
+## INTRODUCTION
+
+stable is generally made up of three pieces:
+
+* `stable add`:
+  Add a dependency to the local `bundle.json`. See `stable-add(1)`.
+* `stable fetch`:
+  Download dependencies listed in the `bundle.json`. See `stable-fetch(1)`
+* `stable env`:
+  Create a build environment to help you use your downloaded dependencies.
+  See `stable-env(1)`
+
+For more information on the `bundle.json` file, see `stable-config(5)`.
+
+## EXAMPLES
+
+* `stable fetch`:
+Download dependencies for your project.
+
+* `stable env ponyc`:
+Run `ponyc` using your downloaded dependencies.
+
+* `stable add github jemc/pony-inspect`:
+Add the project at github.com/jemec/pony-inspect to your project.

--- a/doc/files/stable-config.md
+++ b/doc/files/stable-config.md
@@ -1,0 +1,80 @@
+stable-config(5) -- bundle.json file format
+===========================================
+
+## DESCRIPTION
+
+This page describes the format of the `bundle.json` file. `bundle.json` should
+be at the root of any project which uses `stable` to manage its dependencies.
+As the file suffix suggests, it is a JSON file.
+
+## deps
+
+`bundle.json` currently only has one key at the root of the JSON document:
+`deps`. This is an array of dependencies. A minimal `bundle.json` looks like
+
+    { "deps" : [] }
+
+The contents of this array are dependency objects. All dependency objects
+have a `type`; the rest of the fields depend on the type of dependency.
+
+## github
+
+The `github` type represents a github repository. It has up to four keys:
+
+* `"type"`:
+  **[Required]** For the `github` dependency type, this is `"github"`.
+* `"repo"`:
+  **[Required]** The path of the url for your dependency project. For example,
+  `pony-stable`'s repo would be `"ponylang/pony-stable"`.
+* `"tag"`:
+  [Optional] A specific tag to checkout from the git repo. Technically, this
+  can be any git "tree-ish".
+* `"subdir"`:
+  [Optional] A subdirectory to use as the root of this dependency.
+
+## local-git
+
+The `local-git` type represents a git repository already on your workstation.
+It has up to three keys:
+
+* `"type"`:
+  **[Required]** For the `local-git` dependency type, this is `"local-git"`.
+* `"local-path"`:
+  **[Required]** The filesystem path to your dependency's repository. May be
+  relative.
+* `"tag"`:
+  [Optional] A specific tag to checkout from the git repo. Technically, this
+  can be any git "tree-ish".
+
+## local
+
+The `local` type is any directory on your computer. It does not need to be
+a git repository.
+
+* `"type"`:
+  **[Required]** For the `local` dependency type, this is `"local"`.
+* `"local-path"`:
+  **[Required]** The filesystem path to your dependency's repository. May be
+  relative.
+
+## EXAMPLES
+
+The following is an example of a bundle.json using one of each type of dependency.
+
+    {
+      "deps": [
+        {
+          "type": "github",
+          "repo": "ponylang/pony-stable",
+          "tag": "0.1.0",
+          "subdir": "stable"
+        }, {
+          "type": "local-git",
+          "local-path": "../local-git-project"
+          "tag": "1.1.5",
+        }, {
+          "type": "local",
+          "local-path": "/home/misterEd/pony-project"
+        }
+      ]
+    }

--- a/doc/files/stable-config.md
+++ b/doc/files/stable-config.md
@@ -32,6 +32,22 @@ The `github` type represents a github repository. It has up to four keys:
 * `"subdir"`:
   [Optional] A subdirectory to use as the root of this dependency.
 
+## gitlab
+
+The `gitlab` type represents a gitlab repository. It has up to four keys:
+
+* `"type"`:
+  **[Required]** For the `gitlab` dependency type, this is `"gitlab"`.
+* `"repo"`:
+  **[Required]** The path of the url for your dependency project. For example,
+  `pony-stable`'s repo would be `"ponylang/pony-stable"`.
+* `"tag"`:
+  [Optional] A specific tag to checkout from the git repo. Technically, this
+  can be any git "tree-ish".
+* `"subdir"`:
+  [Optional] A subdirectory to use as the root of this dependency.
+
+
 ## local-git
 
 The `local-git` type represents a git repository already on your workstation.


### PR DESCRIPTION
Hi there,

I was poking around getting into pony and stable looked like a fun place to get my feet wet. I saw you had an issue open to document how to use stable and the bundle.json file format (#19) and figured I'd toss something together for you.

These doc pages can be read as-is, or can be transformed into manpages using [ronn](http://rtomayko.github.io/ronn/) or a few other markdown-to-roff converters. Let me know if you're interested in generating this on travis and getting manpages into your vendored packages.