### PR TITLE
Use `fetch` instead of `pull url` to update .deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Pony compiler and standard library will be documented
 
 ### Fixed
 
+- Fixed issue with the way the `.deps` directory is updated to avoid problems with non-master versions
 
 ### Added
 
@@ -32,4 +33,3 @@ All notable changes to the Pony compiler and standard library will be documented
 ### Added
 
 - Display an error message when add subcommand cannot be found ([PR #39](https://github.com/ponylang/pony-stable/pull/39))
-

--- a/stable/dep.pony
+++ b/stable/dep.pony
@@ -51,7 +51,7 @@ class DepGitHub
   fun ref fetch() ? =>
     let fpath = FilePath(bundle.path, root_path())?
     if fpath.exists() then
-      Shell("git -C " + root_path() + " pull " + url())?
+      Shell("git -C " + root_path() + " fetch")?
     else
       fpath.mkdir()
       Shell("git clone " + url() + " " + root_path())?
@@ -107,7 +107,7 @@ class DepLocal
   let bundle: Bundle box
   let info: JsonObject box
   let local_path: String
-  
+
   new create(b: Bundle box, i: JsonObject box) ? =>
     bundle = b
     info = i
@@ -131,5 +131,5 @@ primitive _CheckoutTag
   fun apply(root_path: String, git_tag: (String | None)) ? =>
     match git_tag
     | let str: String =>
-      Shell("cd " + root_path + " && git checkout " + str)? 
+      Shell("cd " + root_path + " && git checkout " + str)?
     end


### PR DESCRIPTION
If the `.deps` directory already existed then we were running `git -C
[root] pull [url]` and then checking out the commit specified in the
dependencies list. If the commit wasn't master then there could be a
merge conflict, which would cause the checkout to fail, leaving
`.deps` in a bad state.

The solution (for now) is to call `git -C [root] fetch` instead. This
gets the metadata without trying to merge master into the working
copy. We can then safely run the checkout command to get the latest
version of the desired dependency.