### PR TITLE
Run standard ci tasks on circle-ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,36 @@
+version: 2
+jobs:
+  vs-ponyc-release:
+    docker:
+      - image: ponylang/ponyc:release
+    steps:
+      - checkout
+      - run: make test
+  vs-ponyc-master:
+    docker:
+      - image: ponylang/ponyc:latest
+    steps:
+      - checkout
+      - run: make test
+  verify-changelog:
+    docker:
+      - image: ponylang/changelog-tool:release
+    steps:
+      - checkout
+      - run: changelog-tool verify CHANGELOG.md
+
+workflows:
+  version: 2
+  commit:
+    jobs:
+      - verify-changelog
+      - vs-ponyc-release
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only: master
+    jobs:
+      - vs-ponyc-master

--- a/.travis_script.bash
+++ b/.travis_script.bash
@@ -3,26 +3,6 @@
 set -o errexit
 set -o nounset
 
-pony-stable-test(){
-  echo "Running Pony-stable tests"
-  make test
-}
-
-verify-changelog(){
-  echo "Installing stable so we can build changelog tool..."
-  sudo make install
-
-  echo "Building changelog tool..."
-  pushd /tmp
-
-  git clone "https://github.com/ponylang/changelog-tool"
-  cd changelog-tool && git checkout tags/0.2.0 && make && sudo make install && cd -
-
-  popd
-
-  changelog-tool verify CHANGELOG.md
-}
-
 pony-stable-build-packages(){
   echo "Installing ruby, rpm, and fpm..."
   rvm use 2.2.3 --default
@@ -41,7 +21,4 @@ pony-stable-build-packages(){
 if [[ "$TRAVIS_BRANCH" == "release" && "$TRAVIS_PULL_REQUEST" == "false" ]]
 then
   pony-stable-build-packages
-else
-  pony-stable-test
-  verify-changelog
 fi


### PR DESCRIPTION
Makes it easy to test against master on a daily basis and know when that
is failing.

Note, for now, releases will still be done on Travis. Switching releases
to circle-ci doesn't make much sense as we want to switch to using PPAs
etc.