### PR TITLE
Add integration tests for 'stable env'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 build
+/stable/test/integration/tmp/**
+!/stable/test/integration/tmp/.gitkeep
 # generated
 stable/version.pony

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ else
 endif
 
 SOURCE_FILES := $(shell find $(SRC_DIR) -path $(SRC_DIR)/test -prune -o -name \*.pony)
-TEST_FILES := $(shell find $(SRC_DIR)/test -name \*.pony)
+TEST_FILES := $(shell find $(SRC_DIR)/test -name \*.pony -o -name helper.sh)
 VERSION := "$(tag) [$(config)]"
 GEN_FILES_IN := $(shell find $(SRC_DIR) -name \*.pony.in)
 GEN_FILES = $(patsubst %.pony.in, %.pony, $(GEN_FILES_IN))

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ $(tests_binary): $(GEN_FILES) $(SOURCE_FILES) $(TEST_FILES) | $(BUILD_DIR)
 	${PONYC} $(arch_arg) --debug -o ${BUILD_DIR} $(SRC_DIR)/test
 
 integration: $(binary) $(tests_binary)
-	STABLE_BIN=$$(pwd)/$(binary) $(tests_binary) --only=integration
+	STABLE_BIN=$$(pwd)/$(binary) $(tests_binary) --only=integration --sequential
 
 test: $(tests_binary)
 	$^ --exclude=integration

--- a/stable/test/integration/_clean_tmp.pony
+++ b/stable/test/integration/_clean_tmp.pony
@@ -1,0 +1,9 @@
+use "files"
+
+actor _CleanTmp
+  let _fp: FilePath
+  new create(fp: FilePath) =>
+    _fp = fp
+
+  be dispose() =>
+    _fp.remove()

--- a/stable/test/integration/_exec.pony
+++ b/stable/test/integration/_exec.pony
@@ -8,7 +8,6 @@ actor _Exec
     h: TestHelper,
     cmdline: String,
     tmp: String,
-    cleaner: DisposableActor,
     notifier: ProcessNotify iso)
   =>
     let stable_bin =
@@ -31,7 +30,6 @@ actor _Exec
         path, consume args, consume vars)
       pm.done_writing()
       h.dispose_when_done(pm)
-      h.dispose_when_done(cleaner)
     else
       h.fail("Could not create FilePath!")
     end

--- a/stable/test/integration/_exec.pony
+++ b/stable/test/integration/_exec.pony
@@ -7,6 +7,8 @@ actor _Exec
   new create(
     h: TestHelper,
     cmdline: String,
+    tmp: String,
+    cleaner: DisposableActor,
     notifier: ProcessNotify iso)
   =>
     let stable_bin =
@@ -18,13 +20,18 @@ actor _Exec
       end
     try
       let args = cmdline.split_by(" ")
-      let path = FilePath(h.env.root as AmbientAuth, stable_bin)?
-      let vars: Array[String] iso = []
+      let path = FilePath(h.env.root as AmbientAuth,
+        "stable/test/integration/helper.sh")?
       let auth = h.env.root as AmbientAuth
+      let vars: Array[String] iso = [
+        "CWD=" + tmp
+        "STABLE_BIN=" + stable_bin
+        ]
       let pm: ProcessMonitor = ProcessMonitor(auth, auth, consume notifier,
         path, consume args, consume vars)
       pm.done_writing()
       h.dispose_when_done(pm)
+      h.dispose_when_done(cleaner)
     else
       h.fail("Could not create FilePath!")
     end

--- a/stable/test/integration/helper.sh
+++ b/stable/test/integration/helper.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd "$CWD" || exit 100
+exec "$STABLE_BIN" "$@"

--- a/stable/test/integration/helper.sh
+++ b/stable/test/integration/helper.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+# workaround -- see https://github.com/ponylang/ponyc/issues/2821
 cd "$CWD" || exit 100
 exec "$STABLE_BIN" "$@"

--- a/stable/test/integration/test_env.pony
+++ b/stable/test/integration/test_env.pony
@@ -21,7 +21,7 @@ class TestEnvNoBundle is UnitTest
   fun name(): String => "integration.Env(no bundle.json)"
 
   fun apply(h: TestHelper) =>
-    h.long_test(100_000_000)
+    h.long_test(200_000_000)
     let tmp =
       try
         FilePath.mkdtemp(h.env.root as AmbientAuth,
@@ -43,7 +43,7 @@ class TestEnvEmptyBundleInSameDir is UnitTest
   fun name(): String => "integration.Env(empty bundle in same directory)"
 
   fun apply(h: TestHelper) =>
-    h.long_test(100_000_000)
+    h.long_test(200_000_000)
     let tmp =
       try
         FilePath.mkdtemp(h.env.root as AmbientAuth,
@@ -74,7 +74,7 @@ class TestEnvBundleInSameDir is UnitTest
   fun name(): String => "integration.Env(bundle in same directory)"
 
   fun apply(h: TestHelper) =>
-    h.long_test(100_000_000)
+    h.long_test(200_000_000)
     let tmp =
       try
         FilePath.mkdtemp(h.env.root as AmbientAuth,
@@ -121,7 +121,7 @@ class TestEnvBundleInSameDirWithCall is UnitTest
   fun name(): String => "integration.Env(calling a program)"
 
   fun apply(h: TestHelper) =>
-    h.long_test(100_000_000)
+    h.long_test(200_000_000)
     let tmp =
       try
         FilePath.mkdtemp(h.env.root as AmbientAuth,
@@ -155,7 +155,7 @@ class TestEnvBundleInParentDir is UnitTest
   fun name(): String => "integration.Env(bundle.json in parent dir)"
 
   fun apply(h: TestHelper) =>
-    h.long_test(100_000_000)
+    h.long_test(200_000_000)
     let tmp =
       try
         FilePath.mkdtemp(h.env.root as AmbientAuth,
@@ -190,7 +190,7 @@ class TestEnvBadBundleInNestedAndValidBundleInParentDir is UnitTest
   fun name(): String => "integration.Env(invalid bundle.json in nested dir)"
 
   fun apply(h: TestHelper) =>
-    h.long_test(100_000_000)
+    h.long_test(200_000_000)
     let tmp =
       try
         FilePath.mkdtemp(h.env.root as AmbientAuth,

--- a/stable/test/integration/test_env.pony
+++ b/stable/test/integration/test_env.pony
@@ -30,12 +30,13 @@ class TestEnvNoBundle is UnitTest
         h.fail("failed to create temporary directory")
         return
       end
+    h.dispose_when_done(_CleanTmp(tmp))
 
     let notifier: ProcessNotify iso = _ExpectClient(h,
       None,
       ["No bundle.json in current working directory or ancestors."],
       0)
-    _Exec(h, "stable env", tmp.path, _CleanTmp(tmp), consume notifier)
+    _Exec(h, "stable env", tmp.path, consume notifier)
 
 class TestEnvEmptyBundleInSameDir is UnitTest
   new iso create() => None
@@ -52,6 +53,7 @@ class TestEnvEmptyBundleInSameDir is UnitTest
         h.fail("failed to create temporary directory")
         return
       end
+    h.dispose_when_done(_CleanTmp(tmp))
 
     let f =
       try
@@ -66,7 +68,7 @@ class TestEnvEmptyBundleInSameDir is UnitTest
       ["PONYPATH=\n"], // empty
       None,
       0)
-    _Exec(h, "stable env", tmp.path, _CleanTmp(tmp), consume notifier)
+    _Exec(h, "stable env", tmp.path, consume notifier)
 
 class TestEnvBundleInSameDir is UnitTest
   new iso create() => None
@@ -83,6 +85,7 @@ class TestEnvBundleInSameDir is UnitTest
         h.fail("failed to create temporary directory")
         return
       end
+    h.dispose_when_done(_CleanTmp(tmp))
 
     let f =
       try
@@ -113,7 +116,7 @@ class TestEnvBundleInSameDir is UnitTest
       ["PONYPATH=" + expected],
       None,
       0)
-    _Exec(h, "stable env", tmp.path, _CleanTmp(tmp), consume notifier)
+    _Exec(h, "stable env", tmp.path, consume notifier)
 
 class TestEnvBundleInSameDirWithCall is UnitTest
   new iso create() => None
@@ -130,6 +133,7 @@ class TestEnvBundleInSameDirWithCall is UnitTest
         h.fail("failed to create temporary directory")
         return
       end
+    h.dispose_when_done(_CleanTmp(tmp))
 
     let f =
       try
@@ -146,8 +150,7 @@ class TestEnvBundleInSameDirWithCall is UnitTest
       ["../local/a"],
       None,
       0)
-    _Exec(h, "stable env printenv PONYPATH", tmp.path, _CleanTmp(tmp),
-      consume notifier)
+    _Exec(h, "stable env printenv PONYPATH", tmp.path, consume notifier)
 
 class TestEnvBundleInParentDir is UnitTest
   new iso create() => None
@@ -164,6 +167,7 @@ class TestEnvBundleInParentDir is UnitTest
         h.fail("failed to create temporary directory")
         return
       end
+    h.dispose_when_done(_CleanTmp(tmp))
 
     (let f, let nested) =
       try
@@ -182,7 +186,7 @@ class TestEnvBundleInParentDir is UnitTest
       ["PONYPATH=../local/a"],
       None,
       0)
-    _Exec(h, "stable env", nested.path, _CleanTmp(tmp), consume notifier)
+    _Exec(h, "stable env", nested.path, consume notifier)
 
 class TestEnvBadBundleInNestedAndValidBundleInParentDir is UnitTest
   new iso create() => None
@@ -199,6 +203,7 @@ class TestEnvBadBundleInNestedAndValidBundleInParentDir is UnitTest
         h.fail("failed to create temporary directory")
         return
       end
+    h.dispose_when_done(_CleanTmp(tmp))
 
     (let bad_bundle, let good_bundle, let nested) =
       try
@@ -220,4 +225,4 @@ class TestEnvBadBundleInNestedAndValidBundleInParentDir is UnitTest
       ["PONYPATH=../local/a"],
       ["JSON error at: " + bad_bundle.path.path + ": missing \"deps\" array"],
       0)
-    _Exec(h, "stable env", nested.path, _CleanTmp(tmp), consume notifier)
+    _Exec(h, "stable env", nested.path, consume notifier)

--- a/stable/test/integration/test_env.pony
+++ b/stable/test/integration/test_env.pony
@@ -24,7 +24,8 @@ class TestEnvNoBundle is UnitTest
     h.long_test(100_000_000)
     let tmp =
       try
-        FilePath.mkdtemp(h.env.root as AmbientAuth, "")?
+        FilePath.mkdtemp(h.env.root as AmbientAuth,
+          "stable/test/integration/tmp/")?
       else
         h.fail("failed to create temporary directory")
         return
@@ -45,7 +46,8 @@ class TestEnvEmptyBundleInSameDir is UnitTest
     h.long_test(100_000_000)
     let tmp =
       try
-        FilePath.mkdtemp(h.env.root as AmbientAuth, "")?
+        FilePath.mkdtemp(h.env.root as AmbientAuth,
+          "stable/test/integration/tmp/")?
       else
         h.fail("failed to create temporary directory")
         return
@@ -75,7 +77,8 @@ class TestEnvBundleInSameDir is UnitTest
     h.long_test(100_000_000)
     let tmp =
       try
-        FilePath.mkdtemp(h.env.root as AmbientAuth, "")?
+        FilePath.mkdtemp(h.env.root as AmbientAuth,
+          "stable/test/integration/tmp/")?
       else
         h.fail("failed to create temporary directory")
         return
@@ -121,7 +124,8 @@ class TestEnvBundleInSameDirWithCall is UnitTest
     h.long_test(100_000_000)
     let tmp =
       try
-        FilePath.mkdtemp(h.env.root as AmbientAuth, "")?
+        FilePath.mkdtemp(h.env.root as AmbientAuth,
+          "stable/test/integration/tmp/")?
       else
         h.fail("failed to create temporary directory")
         return
@@ -154,7 +158,8 @@ class TestEnvBundleInParentDir is UnitTest
     h.long_test(100_000_000)
     let tmp =
       try
-        FilePath.mkdtemp(h.env.root as AmbientAuth, "")?
+        FilePath.mkdtemp(h.env.root as AmbientAuth,
+          "stable/test/integration/tmp/")?
       else
         h.fail("failed to create temporary directory")
         return
@@ -188,7 +193,8 @@ class TestEnvBadBundleInNestedAndValidBundleInParentDir is UnitTest
     h.long_test(100_000_000)
     let tmp =
       try
-        FilePath.mkdtemp(h.env.root as AmbientAuth, "")?
+        FilePath.mkdtemp(h.env.root as AmbientAuth,
+          "stable/test/integration/tmp/")?
       else
         h.fail("failed to create temporary directory")
         return

--- a/stable/test/integration/test_env.pony
+++ b/stable/test/integration/test_env.pony
@@ -1,0 +1,179 @@
+use "ponytest"
+use "files"
+use "process"
+use ".."
+
+actor EnvTests is TestList
+  new create(env: Env) => PonyTest(env, this)
+  new make() => None
+
+  fun tag tests(test: PonyTest) =>
+    test(TestEnvNoBundle)
+    test(TestEnvEmptyBundleInSameDir)
+    test(TestEnvBundleInSameDir)
+    test(TestEnvBundleInSameDirWithCall)
+    test(TestEnvBundleInParentDir)
+
+class TestEnvNoBundle is UnitTest
+  new iso create() => None
+
+  fun name(): String => "integration.Env(no bundle.json)"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(100_000_000)
+    let tmp =
+      try
+        FilePath.mkdtemp(h.env.root as AmbientAuth, "")?
+      else
+        h.fail("failed to create temporary directory")
+        return
+      end
+
+    let notifier: ProcessNotify iso = _ExpectClient(h,
+      None,
+      ["No bundle.json in current working directory or ancestors."],
+      0)
+    _Exec(h, "stable env", tmp.path, _CleanTmp(tmp), consume notifier)
+
+class TestEnvEmptyBundleInSameDir is UnitTest
+  new iso create() => None
+
+  fun name(): String => "integration.Env(empty bundle in same directory)"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(100_000_000)
+    let tmp =
+      try
+        FilePath.mkdtemp(h.env.root as AmbientAuth, "")?
+      else
+        h.fail("failed to create temporary directory")
+        return
+      end
+
+    let f =
+      try
+        Directory(tmp)?.create_file("bundle.json")?
+      else
+        h.fail("failed to create bundle.json in temporary directory")
+        return
+      end
+    h.assert_true(f.write("{\"deps\":[]}\n"), "prepare bundle.json")
+
+    let notifier: ProcessNotify iso = _ExpectClient(h,
+      ["PONYPATH=\n"], // empty
+      None,
+      0)
+    _Exec(h, "stable env", tmp.path, _CleanTmp(tmp), consume notifier)
+
+class TestEnvBundleInSameDir is UnitTest
+  new iso create() => None
+
+  fun name(): String => "integration.Env(bundle in same directory)"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(100_000_000)
+    let tmp =
+      try
+        FilePath.mkdtemp(h.env.root as AmbientAuth, "")?
+      else
+        h.fail("failed to create temporary directory")
+        return
+      end
+
+    let f =
+      try
+        Directory(tmp)?.create_file("bundle.json")?
+      else
+        h.fail("failed to create bundle.json in temporary directory")
+        return
+      end
+    h.assert_true(f.write("{\"deps\":[
+      {\"type\": \"local\", \"local-path\":\"../local/a\"},
+      {\"type\": \"local-git\", \"local-path\":\"../local-git/b\"},
+      {\"type\": \"github\", \"repo\":\"github/c\"},
+      {\"type\": \"gitlab\", \"repo\":\"gitlab/d\"}
+      ]}\n"), "prepare bundle.json")
+
+    let expected =
+      try
+        "../local/a" + ":" +
+        tmp.join(".deps/-local-git-b16798852821555717647")?.path + ":" +
+        tmp.join(".deps/github/c")?.path + ":" +
+        tmp.join(".deps/gitlab/d")?.path
+      else
+        h.fail("failed to construct expected PONYPATH")
+        return
+      end
+
+    let notifier: ProcessNotify iso = _ExpectClient(h,
+      ["PONYPATH=" + expected],
+      None,
+      0)
+    _Exec(h, "stable env", tmp.path, _CleanTmp(tmp), consume notifier)
+
+class TestEnvBundleInSameDirWithCall is UnitTest
+  new iso create() => None
+
+  fun name(): String => "integration.Env(calling a program)"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(100_000_000)
+    let tmp =
+      try
+        FilePath.mkdtemp(h.env.root as AmbientAuth, "")?
+      else
+        h.fail("failed to create temporary directory")
+        return
+      end
+
+    let f =
+      try
+        Directory(tmp)?.create_file("bundle.json")?
+      else
+        h.fail("failed to create bundle.json in temporary directory")
+        return
+      end
+    h.assert_true(f.write("{\"deps\":[
+      {\"type\": \"local\", \"local-path\":\"../local/a\"}
+      ]}\n"), "prepare bundle.json")
+
+    let notifier: ProcessNotify iso = _ExpectClient(h,
+      ["../local/a"],
+      None,
+      0)
+    _Exec(h, "stable env printenv PONYPATH", tmp.path, _CleanTmp(tmp),
+      consume notifier)
+
+class TestEnvBundleInParentDir is UnitTest
+  new iso create() => None
+
+  fun name(): String => "integration.Env(bundle.json in parent dir)"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(100_000_000)
+    let tmp =
+      try
+        FilePath.mkdtemp(h.env.root as AmbientAuth, "")?
+      else
+        h.fail("failed to create temporary directory")
+        return
+      end
+
+    (let f, let nested) =
+      try
+        h.assert_true(Directory(tmp)?.mkdir("nested"), "create nested directory")
+        let n = tmp.join("nested")?
+        (Directory(tmp)?.create_file("bundle.json")?, n)
+      else
+        h.fail("failed to create bundle.json in nested temporary directory")
+        return
+      end
+    h.assert_true(f.write("{\"deps\":[
+      {\"type\": \"local\", \"local-path\":\"../local/a\"}
+      ]}\n"), "prepare bundle.json")
+
+    let notifier: ProcessNotify iso = _ExpectClient(h,
+      ["PONYPATH=../local/a"],
+      None,
+      0)
+    _Exec(h, "stable env", nested.path, _CleanTmp(tmp), consume notifier)

--- a/stable/test/integration/test_usage.pony
+++ b/stable/test/integration/test_usage.pony
@@ -12,7 +12,7 @@ class TestUsage is UnitTest
   fun name(): String => "integration.Usage(" + _args + ")"
 
   fun apply(h: TestHelper) =>
-    h.long_test(100_000_000)
+    h.long_test(200_000_000)
     let tmp =
       try
         FilePath.mkdtemp(h.env.root as AmbientAuth,

--- a/stable/test/integration/test_usage.pony
+++ b/stable/test/integration/test_usage.pony
@@ -21,6 +21,7 @@ class TestUsage is UnitTest
         h.fail("failed to create temporary directory")
         return
       end
+    h.dispose_when_done(_CleanTmp(tmp))
 
     let notifier: ProcessNotify iso = _ExpectClient(h,
       [ "Usage: stable COMMAND \\[\\.\\.\\.\\]"
@@ -33,4 +34,4 @@ class TestUsage is UnitTest
       ],
       None, // stderr
       0)
-    _Exec(h, "stable " + _args, tmp.path, _CleanTmp(tmp), consume notifier)
+    _Exec(h, "stable " + _args, tmp.path, consume notifier)

--- a/stable/test/integration/test_usage.pony
+++ b/stable/test/integration/test_usage.pony
@@ -1,4 +1,5 @@
 use "ponytest"
+use "files"
 use "process"
 use ".."
 
@@ -12,6 +13,14 @@ class TestUsage is UnitTest
 
   fun apply(h: TestHelper) =>
     h.long_test(100_000_000)
+    let tmp =
+      try
+        FilePath.mkdtemp(h.env.root as AmbientAuth, "")?
+      else
+        h.fail("failed to create temporary directory")
+        return
+      end
+
     let notifier: ProcessNotify iso = _ExpectClient(h,
       [ "Usage: stable COMMAND \\[\\.\\.\\.\\]"
         "A simple dependency manager for the Pony language"
@@ -23,4 +32,4 @@ class TestUsage is UnitTest
       ],
       None, // stderr
       0)
-    _Exec(h, "stable " + _args, consume notifier)
+    _Exec(h, "stable " + _args, tmp.path, _CleanTmp(tmp), consume notifier)

--- a/stable/test/integration/test_usage.pony
+++ b/stable/test/integration/test_usage.pony
@@ -15,7 +15,8 @@ class TestUsage is UnitTest
     h.long_test(100_000_000)
     let tmp =
       try
-        FilePath.mkdtemp(h.env.root as AmbientAuth, "")?
+        FilePath.mkdtemp(h.env.root as AmbientAuth,
+          "stable/test/integration/tmp/")?
       else
         h.fail("failed to create temporary directory")
         return

--- a/stable/test/integration/test_version.pony
+++ b/stable/test/integration/test_version.pony
@@ -8,7 +8,7 @@ class TestVersion is UnitTest
   fun name(): String => "integration.Version"
 
   fun apply(h: TestHelper) =>
-    h.long_test(100_000_000)
+    h.long_test(200_000_000)
     let tmp =
       try
         FilePath.mkdtemp(h.env.root as AmbientAuth,

--- a/stable/test/integration/test_version.pony
+++ b/stable/test/integration/test_version.pony
@@ -1,4 +1,5 @@
 use "ponytest"
+use "files"
 use "process"
 use ".."
 
@@ -8,8 +9,16 @@ class TestVersion is UnitTest
 
   fun apply(h: TestHelper) =>
     h.long_test(100_000_000)
+    let tmp =
+      try
+        FilePath.mkdtemp(h.env.root as AmbientAuth, "")?
+      else
+        h.fail("failed to create temporary directory")
+        return
+      end
+
     let notifier: ProcessNotify iso = _ExpectClient(h,
       ["\\d\\.\\d\\.\\d-[a-f0-9]+ \\[[a-z]+\\]"],
       None, // stderr
       0)
-    _Exec(h, "stable version", consume notifier)
+    _Exec(h, "stable version", tmp.path, _CleanTmp(tmp), consume notifier)

--- a/stable/test/integration/test_version.pony
+++ b/stable/test/integration/test_version.pony
@@ -17,9 +17,10 @@ class TestVersion is UnitTest
         h.fail("failed to create temporary directory")
         return
       end
+    h.dispose_when_done(_CleanTmp(tmp))
 
     let notifier: ProcessNotify iso = _ExpectClient(h,
       ["\\d\\.\\d\\.\\d-[a-f0-9]+ \\[[a-z]+\\]"],
       None, // stderr
       0)
-    _Exec(h, "stable version", tmp.path, _CleanTmp(tmp), consume notifier)
+    _Exec(h, "stable version", tmp.path, consume notifier)

--- a/stable/test/integration/test_version.pony
+++ b/stable/test/integration/test_version.pony
@@ -11,7 +11,8 @@ class TestVersion is UnitTest
     h.long_test(100_000_000)
     let tmp =
       try
-        FilePath.mkdtemp(h.env.root as AmbientAuth, "")?
+        FilePath.mkdtemp(h.env.root as AmbientAuth,
+          "stable/test/integration/tmp/")?
       else
         h.fail("failed to create temporary directory")
         return

--- a/stable/test/main.pony
+++ b/stable/test/main.pony
@@ -11,3 +11,5 @@ actor Main is TestList
     test(integration.TestUsage("help"))
     test(integration.TestUsage("unknown arguments"))
     test(integration.TestVersion)
+
+    integration.EnvTests.make().tests(test)


### PR DESCRIPTION
Turns out this is probably the lowest-hanging fruit right now. This makes
use of the previous commit's "run in temp dir" feature.

Part of #28.

Happy to discuss the approach taken in this PR's first commit -- using the shell wrapper to `cd` into the right place. I've tried getting this to work in some other way -- using an exclusion group for side-stepping concurrency issues in `@chdir`, but couldn't get it to work. After that, the present solution seemed OK enough 😉 

Curious about _all the input_ I can get here `:)` What I dislike most is the duplication in the new env tests, but I couldn't come up with a better structure.