### PR TITLE
Deb packaging for bintray to allow for old version installation

### DIFF
--- a/.bintray_deb.bash
+++ b/.bintray_deb.bash
@@ -1,0 +1,68 @@
+#! /bin/bash
+
+REPO_TYPE=debian
+PACKAGE_VERSION=$1  # e.g., 0.24.0
+DISTRO=$2 # e.g., trusty
+
+if [[ "$PACKAGE_VERSION" == "" ]]; then
+  echo "Error! PACKAGE_VERSION (argument 1) required!"
+  exit 1
+fi
+
+if [[ "$DISTRO" == "" ]]; then
+  echo "Error! DISTRO (argument 2) required!"
+  exit 1
+fi
+
+BINTRAY_REPO_NAME="ponylang-debian"
+OUTPUT_TARGET="bintray_${REPO_TYPE}_${DISTRO}.json"
+
+DATE="$(date +%Y-%m-%d)"
+
+case "$REPO_TYPE" in
+  "debian")
+    FILES="\"files\":
+        [
+          {
+            \"includePattern\": \"/home/travis/build/ponylang/pony-stable/(pony-stable_.*${DISTRO}.*.deb)\", \"uploadPattern\": \"pool/main/p/pony-stable/\$1\",
+            \"matrixParams\": {
+            \"deb_distribution\": \"${DISTRO}\",
+            \"deb_component\": \"main\",
+            \"deb_architecture\": \"amd64\"}
+         }
+       ],
+       \"publish\": true"
+    ;;
+esac
+
+JSON="{
+  \"package\": {
+    \"repo\": \"$BINTRAY_REPO_NAME\",
+    \"name\": \"pony-stable\",
+    \"subject\": \"pony-language\",
+    \"website_url\": \"https://www.ponylang.org/\",
+    \"issue_tracker_url\": \"https://github.com/ponylang/pony-stable/issues\",
+    \"vcs_url\": \"https://github.com/ponylang/pony-stable.git\",
+    \"licenses\": [\"BSD 2-Clause\"],
+    \"github_repo\": \"ponylang/pony-stable\",
+    \"github_release_notes_file\": \"CHANGELOG.md\"
+    \"public_download_numbers\": true
+  },
+  \"version\": {
+    \"name\": \"$PACKAGE_VERSION\",
+    \"desc\": \"pony-stable release $PACKAGE_VERSION\",
+    \"released\": \"$DATE\",
+    \"vcs_tag\": \"$PACKAGE_VERSION\",
+    \"github_use_tag_release_notes\": true,
+    \"github_release_notes_file\": \"CHANGELOG.md\"
+  },"
+
+JSON="$JSON$FILES}"
+
+echo "Writing JSON to file: $OUTPUT_TARGET, from within $(pwd) ..."
+echo "$JSON" > "$OUTPUT_TARGET"
+
+echo "=== WRITTEN FILE =========================="
+cat -v "$OUTPUT_TARGET"
+echo "==========================================="
+

--- a/.packaging/deb/rules
+++ b/.packaging/deb/rules
@@ -36,6 +36,12 @@ override_dh_auto_install:
 override_dh_auto_test:
 	dh_auto_test -- $(MAKE_OPTIONS)
 
+# if newer debian/ubuntu disable unform compression in deb for bintray
+ifeq (,$(filter $(DEB_DISTRIBUTION),jessie stretch trusty xenial artful))
+override_dh_builddeb:
+	dh_builddeb -- --no-uniform-compression
+endif
+
 # dh_make generated override targets
 # This is example for Cmake (See https://bugs.debian.org/641051 )
 #override_dh_auto_configure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,3 +52,73 @@ deploy:
       branch: release
     key:
       secure: "BsQuv9cfqG2O5Qvz4rdtHJ7QnjorOzPM2obbzpTA33MqtWR9NPS/W26RPUdMEGspUT72j6PNjbcgV4LXcysVQQLLoVRzPU9sy8U/fW00Om/RkyOa0ia5D3U4OWCme2rkTA/QAnkCT5E8hgx/TLtpbfTWmwiTqpi2toNuAjKXpHsGaXYQaQH6VjSzosTsdnhpwynCQA5qnHw/Wn3vEI2dt+ZvLE3xsVkU+1QoSWGsqBCoEXEZXAyxh4UcsBDHfgUaKGMZbbeXTZBFhCuCzQwMXruW0MLOJJEpGgCxY34KPFgVKyOk/2A7TfrzsZeBm2I6Dx/raLWU28cUNdIR2JYepbImqO8neGmDarskHPf+Kj9t8KrKm7yFXpBIjq1wpL7qcLEWIFolnbAreDZVaR+7wbai9r8iUergjLVlL+2Fs3vAMCSniFXWZtekHoa7YHKnVesq5ElHHLDc+1PiHM7S0QSClUvSzcQHWj0icnvzzLuO4oPc3Qc668uk7/XraTcHrqU4G59co2Co6egcK4fGOcGYWEbEamoR34JAiLlar2iAu3BiBAJBCDNbSbcs1JwL6b4KQD58j7VXYHE5mjEFNA96yG54siHRqbFXGhef/nc0+Wo3QpgH5sYYLUn84/aJbs49S/hyqtxTDsp5vUNWGUhADatMFWhY4KNBvnjjUcs="
+
+  - provider: bintray
+    user: pony-buildbot-2
+    file: /home/travis/build/ponylang/pony-stable/bintray_debian_trusty.json
+    skip_cleanup: true
+    on:
+      branch: release
+
+    key:
+      secure: "GGDPvrwx0nY09smgUP0ocbBCIdvl1r96bzM7NYxxS9l9d6xGegaSFzUF6B19mdIRT4A+mR9fxpc2eQpxC6iduWVOWGwXGqtYtWzKz/C1I3s/UICPWDl2f4wsO8KGqcO2+M87aw3bwUKC4GgzKa956HKm8BVeCWhbwyFSf0c4UyST8Lkv2vAFWeRDmu/fzUwwFFpiHwlE7W1rlJhQV2xiY8pwVntgxAmTL5ssSOYdk+t65H1fIfjF3k+dU0KkARa8y2JaVhtYHlisHjCki2V3hhKenGcoK22WnNckaCM9sn/ppCm6KRhqcbtGrbEYu8XAA/xXnw3xtgZWVHhcLdTXDl13rxCGchdF1f2rtEZCfI9BSJeQlLBRrf8lF9rEdLgfUqOKSq47KKrENa5PclhGiby9iICBuzRMJxbKUvXo8dcCvFP+/Q8ekIMyAItIK/AJBX9Gx4Yv25g8n5XZDzgfNlOEou27emo7zv1/nCEZkwKQyfHAEbnpz56y0JaR+eMotBdLIHsDNZSAh+/tWNiUYBaKfZydawrnHlWxiX8diMEOqZWHhlIHRljCmt2NUxAevht2mzzoZ+NBZxfyaDcw0dt8A1cGpigZh995Pj+LaFidPK7lvIwJGJ1956Iaj+wnZxJCkCOHuTLtO5KYDTIlgbmd7vVQfX5wm9uKsrsifF8="
+
+  - provider: bintray
+    user: pony-buildbot-2
+    file: /home/travis/build/ponylang/pony-stable/bintray_debian_xenial.json
+    skip_cleanup: true
+    on:
+      branch: release
+
+    key:
+      secure: "GGDPvrwx0nY09smgUP0ocbBCIdvl1r96bzM7NYxxS9l9d6xGegaSFzUF6B19mdIRT4A+mR9fxpc2eQpxC6iduWVOWGwXGqtYtWzKz/C1I3s/UICPWDl2f4wsO8KGqcO2+M87aw3bwUKC4GgzKa956HKm8BVeCWhbwyFSf0c4UyST8Lkv2vAFWeRDmu/fzUwwFFpiHwlE7W1rlJhQV2xiY8pwVntgxAmTL5ssSOYdk+t65H1fIfjF3k+dU0KkARa8y2JaVhtYHlisHjCki2V3hhKenGcoK22WnNckaCM9sn/ppCm6KRhqcbtGrbEYu8XAA/xXnw3xtgZWVHhcLdTXDl13rxCGchdF1f2rtEZCfI9BSJeQlLBRrf8lF9rEdLgfUqOKSq47KKrENa5PclhGiby9iICBuzRMJxbKUvXo8dcCvFP+/Q8ekIMyAItIK/AJBX9Gx4Yv25g8n5XZDzgfNlOEou27emo7zv1/nCEZkwKQyfHAEbnpz56y0JaR+eMotBdLIHsDNZSAh+/tWNiUYBaKfZydawrnHlWxiX8diMEOqZWHhlIHRljCmt2NUxAevht2mzzoZ+NBZxfyaDcw0dt8A1cGpigZh995Pj+LaFidPK7lvIwJGJ1956Iaj+wnZxJCkCOHuTLtO5KYDTIlgbmd7vVQfX5wm9uKsrsifF8="
+
+  - provider: bintray
+    user: pony-buildbot-2
+    file: /home/travis/build/ponylang/pony-stable/bintray_debian_artful.json
+    skip_cleanup: true
+    on:
+      branch: release
+
+    key:
+      secure: "GGDPvrwx0nY09smgUP0ocbBCIdvl1r96bzM7NYxxS9l9d6xGegaSFzUF6B19mdIRT4A+mR9fxpc2eQpxC6iduWVOWGwXGqtYtWzKz/C1I3s/UICPWDl2f4wsO8KGqcO2+M87aw3bwUKC4GgzKa956HKm8BVeCWhbwyFSf0c4UyST8Lkv2vAFWeRDmu/fzUwwFFpiHwlE7W1rlJhQV2xiY8pwVntgxAmTL5ssSOYdk+t65H1fIfjF3k+dU0KkARa8y2JaVhtYHlisHjCki2V3hhKenGcoK22WnNckaCM9sn/ppCm6KRhqcbtGrbEYu8XAA/xXnw3xtgZWVHhcLdTXDl13rxCGchdF1f2rtEZCfI9BSJeQlLBRrf8lF9rEdLgfUqOKSq47KKrENa5PclhGiby9iICBuzRMJxbKUvXo8dcCvFP+/Q8ekIMyAItIK/AJBX9Gx4Yv25g8n5XZDzgfNlOEou27emo7zv1/nCEZkwKQyfHAEbnpz56y0JaR+eMotBdLIHsDNZSAh+/tWNiUYBaKfZydawrnHlWxiX8diMEOqZWHhlIHRljCmt2NUxAevht2mzzoZ+NBZxfyaDcw0dt8A1cGpigZh995Pj+LaFidPK7lvIwJGJ1956Iaj+wnZxJCkCOHuTLtO5KYDTIlgbmd7vVQfX5wm9uKsrsifF8="
+
+  - provider: bintray
+    user: pony-buildbot-2
+    file: /home/travis/build/ponylang/pony-stable/bintray_debian_bionic.json
+    skip_cleanup: true
+    on:
+      branch: release
+
+    key:
+      secure: "GGDPvrwx0nY09smgUP0ocbBCIdvl1r96bzM7NYxxS9l9d6xGegaSFzUF6B19mdIRT4A+mR9fxpc2eQpxC6iduWVOWGwXGqtYtWzKz/C1I3s/UICPWDl2f4wsO8KGqcO2+M87aw3bwUKC4GgzKa956HKm8BVeCWhbwyFSf0c4UyST8Lkv2vAFWeRDmu/fzUwwFFpiHwlE7W1rlJhQV2xiY8pwVntgxAmTL5ssSOYdk+t65H1fIfjF3k+dU0KkARa8y2JaVhtYHlisHjCki2V3hhKenGcoK22WnNckaCM9sn/ppCm6KRhqcbtGrbEYu8XAA/xXnw3xtgZWVHhcLdTXDl13rxCGchdF1f2rtEZCfI9BSJeQlLBRrf8lF9rEdLgfUqOKSq47KKrENa5PclhGiby9iICBuzRMJxbKUvXo8dcCvFP+/Q8ekIMyAItIK/AJBX9Gx4Yv25g8n5XZDzgfNlOEou27emo7zv1/nCEZkwKQyfHAEbnpz56y0JaR+eMotBdLIHsDNZSAh+/tWNiUYBaKfZydawrnHlWxiX8diMEOqZWHhlIHRljCmt2NUxAevht2mzzoZ+NBZxfyaDcw0dt8A1cGpigZh995Pj+LaFidPK7lvIwJGJ1956Iaj+wnZxJCkCOHuTLtO5KYDTIlgbmd7vVQfX5wm9uKsrsifF8="
+
+  - provider: bintray
+    user: pony-buildbot-2
+    file: /home/travis/build/ponylang/pony-stable/bintray_debian_jessie.json
+    skip_cleanup: true
+    on:
+      branch: release
+
+    key:
+      secure: "GGDPvrwx0nY09smgUP0ocbBCIdvl1r96bzM7NYxxS9l9d6xGegaSFzUF6B19mdIRT4A+mR9fxpc2eQpxC6iduWVOWGwXGqtYtWzKz/C1I3s/UICPWDl2f4wsO8KGqcO2+M87aw3bwUKC4GgzKa956HKm8BVeCWhbwyFSf0c4UyST8Lkv2vAFWeRDmu/fzUwwFFpiHwlE7W1rlJhQV2xiY8pwVntgxAmTL5ssSOYdk+t65H1fIfjF3k+dU0KkARa8y2JaVhtYHlisHjCki2V3hhKenGcoK22WnNckaCM9sn/ppCm6KRhqcbtGrbEYu8XAA/xXnw3xtgZWVHhcLdTXDl13rxCGchdF1f2rtEZCfI9BSJeQlLBRrf8lF9rEdLgfUqOKSq47KKrENa5PclhGiby9iICBuzRMJxbKUvXo8dcCvFP+/Q8ekIMyAItIK/AJBX9Gx4Yv25g8n5XZDzgfNlOEou27emo7zv1/nCEZkwKQyfHAEbnpz56y0JaR+eMotBdLIHsDNZSAh+/tWNiUYBaKfZydawrnHlWxiX8diMEOqZWHhlIHRljCmt2NUxAevht2mzzoZ+NBZxfyaDcw0dt8A1cGpigZh995Pj+LaFidPK7lvIwJGJ1956Iaj+wnZxJCkCOHuTLtO5KYDTIlgbmd7vVQfX5wm9uKsrsifF8="
+
+  - provider: bintray
+    user: pony-buildbot-2
+    file: /home/travis/build/ponylang/pony-stable/bintray_debian_stretch.json
+    skip_cleanup: true
+    on:
+      branch: release
+
+    key:
+      secure: "GGDPvrwx0nY09smgUP0ocbBCIdvl1r96bzM7NYxxS9l9d6xGegaSFzUF6B19mdIRT4A+mR9fxpc2eQpxC6iduWVOWGwXGqtYtWzKz/C1I3s/UICPWDl2f4wsO8KGqcO2+M87aw3bwUKC4GgzKa956HKm8BVeCWhbwyFSf0c4UyST8Lkv2vAFWeRDmu/fzUwwFFpiHwlE7W1rlJhQV2xiY8pwVntgxAmTL5ssSOYdk+t65H1fIfjF3k+dU0KkARa8y2JaVhtYHlisHjCki2V3hhKenGcoK22WnNckaCM9sn/ppCm6KRhqcbtGrbEYu8XAA/xXnw3xtgZWVHhcLdTXDl13rxCGchdF1f2rtEZCfI9BSJeQlLBRrf8lF9rEdLgfUqOKSq47KKrENa5PclhGiby9iICBuzRMJxbKUvXo8dcCvFP+/Q8ekIMyAItIK/AJBX9Gx4Yv25g8n5XZDzgfNlOEou27emo7zv1/nCEZkwKQyfHAEbnpz56y0JaR+eMotBdLIHsDNZSAh+/tWNiUYBaKfZydawrnHlWxiX8diMEOqZWHhlIHRljCmt2NUxAevht2mzzoZ+NBZxfyaDcw0dt8A1cGpigZh995Pj+LaFidPK7lvIwJGJ1956Iaj+wnZxJCkCOHuTLtO5KYDTIlgbmd7vVQfX5wm9uKsrsifF8="
+
+  - provider: bintray
+    user: pony-buildbot-2
+    file: /home/travis/build/ponylang/pony-stable/bintray_debian_buster.json
+    skip_cleanup: true
+    on:
+      branch: release
+
+    key:
+      secure: "GGDPvrwx0nY09smgUP0ocbBCIdvl1r96bzM7NYxxS9l9d6xGegaSFzUF6B19mdIRT4A+mR9fxpc2eQpxC6iduWVOWGwXGqtYtWzKz/C1I3s/UICPWDl2f4wsO8KGqcO2+M87aw3bwUKC4GgzKa956HKm8BVeCWhbwyFSf0c4UyST8Lkv2vAFWeRDmu/fzUwwFFpiHwlE7W1rlJhQV2xiY8pwVntgxAmTL5ssSOYdk+t65H1fIfjF3k+dU0KkARa8y2JaVhtYHlisHjCki2V3hhKenGcoK22WnNckaCM9sn/ppCm6KRhqcbtGrbEYu8XAA/xXnw3xtgZWVHhcLdTXDl13rxCGchdF1f2rtEZCfI9BSJeQlLBRrf8lF9rEdLgfUqOKSq47KKrENa5PclhGiby9iICBuzRMJxbKUvXo8dcCvFP+/Q8ekIMyAItIK/AJBX9Gx4Yv25g8n5XZDzgfNlOEou27emo7zv1/nCEZkwKQyfHAEbnpz56y0JaR+eMotBdLIHsDNZSAh+/tWNiUYBaKfZydawrnHlWxiX8diMEOqZWHhlIHRljCmt2NUxAevht2mzzoZ+NBZxfyaDcw0dt8A1cGpigZh995Pj+LaFidPK7lvIwJGJ1956Iaj+wnZxJCkCOHuTLtO5KYDTIlgbmd7vVQfX5wm9uKsrsifF8="


### PR DESCRIPTION
With the introduction of deb packaging/distribution via Ubuntu
Launchpad PPA, we lost the ability for folks to be able to install
old versions of pony-stable via their package manager. See:
https://github.com/ansible/ansible/issues/23143 for more info.
This commit switches back from Launchpad to Bintray for
hosting/distribution of deb packages. This necessitated that we
build the deb packages ourselves.

This PR includes changes to the travis job to build all the
debian version packages for both ubuntu and debian distros. The
changes also include uploading the packages to a new bintray debian
repo.

Unfortunately, I ran into some issues with using `sbuild` on trusty
so I had to fall back to using docker containers for building the
packages for the different distros.