### PR TITLE
integration: add h.complete(false) to integration test failures, bump timeouts to 2s

### DIFF
--- a/stable/test/integration/_exec.pony
+++ b/stable/test/integration/_exec.pony
@@ -15,6 +15,7 @@ actor _Exec
          _env_var(h.env.vars, "STABLE_BIN")?
       else
         h.fail("STABLE_BIN not set")
+        h.complete(false)
         return
       end
     try
@@ -32,6 +33,7 @@ actor _Exec
       h.dispose_when_done(pm)
     else
       h.fail("Could not create FilePath!")
+      h.complete(false)
     end
 
   fun _env_var(vars: Array[String] val, key: String): String ? =>

--- a/stable/test/integration/test_env.pony
+++ b/stable/test/integration/test_env.pony
@@ -28,6 +28,7 @@ class TestEnvNoBundle is UnitTest
           "stable/test/integration/tmp/")?
       else
         h.fail("failed to create temporary directory")
+        h.complete(false)
         return
       end
     h.dispose_when_done(_CleanTmp(tmp))
@@ -51,6 +52,7 @@ class TestEnvEmptyBundleInSameDir is UnitTest
           "stable/test/integration/tmp/")?
       else
         h.fail("failed to create temporary directory")
+        h.complete(false)
         return
       end
     h.dispose_when_done(_CleanTmp(tmp))
@@ -60,6 +62,7 @@ class TestEnvEmptyBundleInSameDir is UnitTest
         Directory(tmp)?.create_file("bundle.json")?
       else
         h.fail("failed to create bundle.json in temporary directory")
+        h.complete(false)
         return
       end
     h.assert_true(f.write("{\"deps\":[]}\n"), "prepare bundle.json")
@@ -83,6 +86,7 @@ class TestEnvBundleInSameDir is UnitTest
           "stable/test/integration/tmp/")?
       else
         h.fail("failed to create temporary directory")
+        h.complete(false)
         return
       end
     h.dispose_when_done(_CleanTmp(tmp))
@@ -92,6 +96,7 @@ class TestEnvBundleInSameDir is UnitTest
         Directory(tmp)?.create_file("bundle.json")?
       else
         h.fail("failed to create bundle.json in temporary directory")
+        h.complete(false)
         return
       end
     h.assert_true(f.write("{\"deps\":[
@@ -109,6 +114,7 @@ class TestEnvBundleInSameDir is UnitTest
         tmp.join(".deps/gitlab/d")?.path
       else
         h.fail("failed to construct expected PONYPATH")
+        h.complete(false)
         return
       end
 
@@ -131,6 +137,7 @@ class TestEnvBundleInSameDirWithCall is UnitTest
           "stable/test/integration/tmp/")?
       else
         h.fail("failed to create temporary directory")
+        h.complete(false)
         return
       end
     h.dispose_when_done(_CleanTmp(tmp))
@@ -140,6 +147,7 @@ class TestEnvBundleInSameDirWithCall is UnitTest
         Directory(tmp)?.create_file("bundle.json")?
       else
         h.fail("failed to create bundle.json in temporary directory")
+        h.complete(false)
         return
       end
     h.assert_true(f.write("{\"deps\":[
@@ -165,6 +173,7 @@ class TestEnvBundleInParentDir is UnitTest
           "stable/test/integration/tmp/")?
       else
         h.fail("failed to create temporary directory")
+        h.complete(false)
         return
       end
     h.dispose_when_done(_CleanTmp(tmp))
@@ -176,6 +185,7 @@ class TestEnvBundleInParentDir is UnitTest
         (Directory(tmp)?.create_file("bundle.json")?, n)
       else
         h.fail("failed to create bundle.json in nested temporary directory")
+        h.complete(false)
         return
       end
     h.assert_true(f.write("{\"deps\":[
@@ -201,6 +211,7 @@ class TestEnvBadBundleInNestedAndValidBundleInParentDir is UnitTest
           "stable/test/integration/tmp/")?
       else
         h.fail("failed to create temporary directory")
+        h.complete(false)
         return
       end
     h.dispose_when_done(_CleanTmp(tmp))
@@ -214,6 +225,7 @@ class TestEnvBadBundleInNestedAndValidBundleInParentDir is UnitTest
          n)
       else
         h.fail("failed to create bundle.json example data files")
+        h.complete(false)
         return
       end
     h.assert_true(good_bundle.write("{\"deps\":[

--- a/stable/test/integration/test_env.pony
+++ b/stable/test/integration/test_env.pony
@@ -21,7 +21,7 @@ class TestEnvNoBundle is UnitTest
   fun name(): String => "integration.Env(no bundle.json)"
 
   fun apply(h: TestHelper) =>
-    h.long_test(200_000_000)
+    h.long_test(2_000_000_000)
     let tmp =
       try
         FilePath.mkdtemp(h.env.root as AmbientAuth,
@@ -45,7 +45,7 @@ class TestEnvEmptyBundleInSameDir is UnitTest
   fun name(): String => "integration.Env(empty bundle in same directory)"
 
   fun apply(h: TestHelper) =>
-    h.long_test(200_000_000)
+    h.long_test(2_000_000_000)
     let tmp =
       try
         FilePath.mkdtemp(h.env.root as AmbientAuth,
@@ -79,7 +79,7 @@ class TestEnvBundleInSameDir is UnitTest
   fun name(): String => "integration.Env(bundle in same directory)"
 
   fun apply(h: TestHelper) =>
-    h.long_test(200_000_000)
+    h.long_test(2_000_000_000)
     let tmp =
       try
         FilePath.mkdtemp(h.env.root as AmbientAuth,
@@ -130,7 +130,7 @@ class TestEnvBundleInSameDirWithCall is UnitTest
   fun name(): String => "integration.Env(calling a program)"
 
   fun apply(h: TestHelper) =>
-    h.long_test(200_000_000)
+    h.long_test(2_000_000_000)
     let tmp =
       try
         FilePath.mkdtemp(h.env.root as AmbientAuth,
@@ -166,7 +166,7 @@ class TestEnvBundleInParentDir is UnitTest
   fun name(): String => "integration.Env(bundle.json in parent dir)"
 
   fun apply(h: TestHelper) =>
-    h.long_test(200_000_000)
+    h.long_test(2_000_000_000)
     let tmp =
       try
         FilePath.mkdtemp(h.env.root as AmbientAuth,
@@ -204,7 +204,7 @@ class TestEnvBadBundleInNestedAndValidBundleInParentDir is UnitTest
   fun name(): String => "integration.Env(invalid bundle.json in nested dir)"
 
   fun apply(h: TestHelper) =>
-    h.long_test(200_000_000)
+    h.long_test(2_000_000_000)
     let tmp =
       try
         FilePath.mkdtemp(h.env.root as AmbientAuth,

--- a/stable/test/integration/test_usage.pony
+++ b/stable/test/integration/test_usage.pony
@@ -12,7 +12,7 @@ class TestUsage is UnitTest
   fun name(): String => "integration.Usage(" + _args + ")"
 
   fun apply(h: TestHelper) =>
-    h.long_test(200_000_000)
+    h.long_test(2_000_000_000)
     let tmp =
       try
         FilePath.mkdtemp(h.env.root as AmbientAuth,

--- a/stable/test/integration/test_version.pony
+++ b/stable/test/integration/test_version.pony
@@ -8,7 +8,7 @@ class TestVersion is UnitTest
   fun name(): String => "integration.Version"
 
   fun apply(h: TestHelper) =>
-    h.long_test(200_000_000)
+    h.long_test(2_000_000_000)
     let tmp =
       try
         FilePath.mkdtemp(h.env.root as AmbientAuth,


### PR DESCRIPTION
The reason this timed out could be that it didn't call `h.complete(..)` when failing. I'm not certain yet, but lets see of this shines some light on it...

Update: didn't seem so, and we should still have seen output. So, assuming that this is a genuine timeout, this bumps the test time outs for all integration test cases to 2s.