### PR TITLE
Initial version of nightly packaging builds

### DIFF
--- a/.travis_script.bash
+++ b/.travis_script.bash
@@ -139,6 +139,13 @@ pony-stable-build-packages(){
   make arch=x86-64 package_name="pony-stable" package_base_version="$(cat VERSION)" package_iteration="${PACKAGE_ITERATION}" deploy
 }
 
+# nightly builds
+if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_EVENT_TYPE" == "cron" ]]
+then
+  pony-stable-build-debs master
+fi
+
+# normal release logic
 if [[ "$TRAVIS_BRANCH" == "release" && "$TRAVIS_PULL_REQUEST" == "false" ]]
 then
   pony-stable-build-debs "$(cat VERSION)"


### PR DESCRIPTION
NOTE: This will require the cron job functionality to be enabled through the Travis UI (https://docs.travis-ci.com/user/cron-jobs/).

-------------------------------

Currently only builds debian packages and doesn't save any packages
built but will be useful to catch any packaging related issues.