### PR TITLE
Add Docker Files for Container Based Development & Testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,9 @@ deploy: all
 	$(SILENT)rm -rf $(package) build/bin/$(archive)
 endef
 
+dshell:
+	@docker-compose run --rm pony
+
 $(eval $(call EXPAND_DEPLOY))
 
 .PHONY: all clean deploy install test integration

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "2.4"
+
+services:
+  pony:
+    image: ponylang/ponyc:release
+    entrypoint: bash
+    working_dir: /stable
+    volumes:
+      - .:/stable


### PR DESCRIPTION
This will make it a lot simpler for developers to run the tests prior to
submitting their PR. This new `make` target, `dshell`, will put developers into a
bash shell, using the same container images that are used for CI.

From there deveopers can run `make test integration`.

I've written about this pattern on my blog:

https://rawkode.com/2018/01/27/docker-shell-pattern/