### PR TITLE
Initial version of AppImage packaging for pony-stable

### DIFF
--- a/.bintray.bash
+++ b/.bintray.bash
@@ -38,6 +38,13 @@ case "$REPO_TYPE" in
       ],
     \"publish\": true"
     ;;
+  "appimage")
+    FILES="\"files\":
+      [
+        {\"includePattern\": \"/home/travis/build/ponylang/pony-stable/(.*.AppImage)\", \"uploadPattern\": \"\$1\"}
+      ],
+    \"publish\": true"
+    ;;
 esac
 
 JSON="{

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,15 @@ deploy:
 
   - provider: bintray
     user: pony-buildbot-2
+    file: /home/travis/build/ponylang/pony-stable/bintray_appimage.json
+    skip_cleanup: true
+    on:
+      branch: release
+    key:
+      secure: "BsQuv9cfqG2O5Qvz4rdtHJ7QnjorOzPM2obbzpTA33MqtWR9NPS/W26RPUdMEGspUT72j6PNjbcgV4LXcysVQQLLoVRzPU9sy8U/fW00Om/RkyOa0ia5D3U4OWCme2rkTA/QAnkCT5E8hgx/TLtpbfTWmwiTqpi2toNuAjKXpHsGaXYQaQH6VjSzosTsdnhpwynCQA5qnHw/Wn3vEI2dt+ZvLE3xsVkU+1QoSWGsqBCoEXEZXAyxh4UcsBDHfgUaKGMZbbeXTZBFhCuCzQwMXruW0MLOJJEpGgCxY34KPFgVKyOk/2A7TfrzsZeBm2I6Dx/raLWU28cUNdIR2JYepbImqO8neGmDarskHPf+Kj9t8KrKm7yFXpBIjq1wpL7qcLEWIFolnbAreDZVaR+7wbai9r8iUergjLVlL+2Fs3vAMCSniFXWZtekHoa7YHKnVesq5ElHHLDc+1PiHM7S0QSClUvSzcQHWj0icnvzzLuO4oPc3Qc668uk7/XraTcHrqU4G59co2Co6egcK4fGOcGYWEbEamoR34JAiLlar2iAu3BiBAJBCDNbSbcs1JwL6b4KQD58j7VXYHE5mjEFNA96yG54siHRqbFXGhef/nc0+Wo3QpgH5sYYLUn84/aJbs49S/hyqtxTDsp5vUNWGUhADatMFWhY4KNBvnjjUcs="
+
+  - provider: bintray
+    user: pony-buildbot-2
     file: /home/travis/build/ponylang/pony-stable/bintray_debian_trusty.json
     skip_cleanup: true
     on:


### PR DESCRIPTION
NOTE: The bintray upload will fail until a generic repo with the name `pony-stable-appimage` is created in the pony-language bintray account.

----------------------------------

See https://appimage.org/ for more info about the AppImage format.

The AppImage packages are built in a CentOS 7 docker image and
should theoretically be compatible with all glibc based x86_64
distros with the same or a newer glibc version.

This commit also fixes an issue with the nighly build of debian
packages.