### PR TITLE
Update installation instructions for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,10 @@ rpm --import pubkey.gpg
 zypper install pony-stable
 ```
 
-### Arch-Linux (AUR)
+### Arch Linux
 
 ```bash
-pacaur -S pony-stable-git
+pacman -S pony-stable
 ```
 
 ### From Source


### PR DESCRIPTION
pony-stable is now available in the official repository [community].