### PR TITLE
Don't process already-seen paths

### DIFF
--- a/stable/bundle.pony
+++ b/stable/bundle.pony
@@ -68,15 +68,24 @@ class Bundle
       try Bundle(FilePath(path, dep.root_path())?, log)?.fetch() end
     end
 
-  fun paths(): Array[String] val =>
+  fun paths(seen_paths: Array[String] = []): Array[String] val =>
     let out = recover trn Array[String] end
+
     for dep in deps() do
-      out.push(dep.packages_path())
+      let dep_path = dep.packages_path()
+      if (not seen_paths.contains(dep_path, {(x,y) => x == y})) then
+        out.push(dep_path)
+        seen_paths.push(dep_path)
+      end
     end
+
     for dep in deps() do
-      // TODO: detect and prevent infinite recursion here.
-      try
-        out.append(Bundle(FilePath(path, dep.packages_path())?, log)?.paths())
+      let dep_path' = dep.packages_path()
+      if (not seen_paths.contains(dep_path', {(x,y) => x == y})) then
+        try
+          out.append(Bundle(FilePath(path, dep_path')?, log)?
+            .paths(seen_paths.clone()))
+        end
       end
     end
     out

--- a/stable/test/main.pony
+++ b/stable/test/main.pony
@@ -7,6 +7,8 @@ actor Main is TestList
 
   fun tag tests(test: PonyTest) =>
     test(TestBundle)
+    test(TestBundleSelfReferentialPaths)
+    test(TestBundleMutuallyRecursivePaths)
     test(TestDep)
     PrivateTests.make().tests(test)
 

--- a/stable/test/test_bundle.pony
+++ b/stable/test/test_bundle.pony
@@ -20,6 +20,7 @@ class TestBundle is UnitTest
     h.assert_no_error(_BundleCreate(h.env, bundle("local-git"))?, "local-git dep")
     h.assert_no_error(_BundleCreate(h.env, bundle("local"))?, "local dep")
 
+
     h.assert_no_error(_BundleCreate(h.env, bundle("abitofeverything"))?, "mixed deps")
 
     h.assert_error(_BundleCreate(h.env, "notfound", true)?, "create in nonexistant directory")
@@ -39,6 +40,38 @@ class TestBundle is UnitTest
     else
       h.log("failed to clean up " + created_bundle)
     end
+
+class TestBundleSelfReferentialPaths is UnitTest
+  new iso create() => None
+  fun name(): String => "stable.Bundle.self-referential-paths"
+
+  fun apply(h: TestHelper) ? =>
+    let b = Bundle(_Path(h.env, "self-referential")?) ?
+    let paths = b.paths()
+    h.assert_eq[USize](1, paths.size())
+    h.assert_true(paths(0)?
+     .contains("stable/test/testdata/self-referential"))
+
+class TestBundleMutuallyRecursivePaths is UnitTest
+  new iso create() => None
+  fun name(): String => "stable.Bundle.mutually-recursive-paths"
+  fun apply(h: TestHelper) ? =>
+    let bar_paths = Bundle(_Path(h.env, "mutually-recursive/bar")?)?.paths()
+    let foo_paths = Bundle(_Path(h.env, "mutually-recursive/foo")?)?.paths()
+
+    h.assert_eq[USize](1, bar_paths.size())
+    h.assert_true(bar_paths(0)?
+     .contains("stable/test/testdata/mutually-recursive/foo"))
+
+    h.assert_eq[USize](1, foo_paths.size())
+    h.assert_true(foo_paths(0)?
+     .contains("stable/test/testdata/mutually-recursive/bar"))
+
+primitive _Path
+  fun apply(env: Env, relative_path: String) : FilePath ? =>
+    FilePath(env.root as AmbientAuth,
+      Path.join("stable/test/testdata", relative_path)
+        .string())?
 
 class _BundleCreate is ITest
   let path: FilePath

--- a/stable/test/testdata/mutually-recursive/bar/bundle.json
+++ b/stable/test/testdata/mutually-recursive/bar/bundle.json
@@ -1,0 +1,1 @@
+{"deps":[{"local-path":"../foo","type":"local"}]}

--- a/stable/test/testdata/mutually-recursive/foo/bundle.json
+++ b/stable/test/testdata/mutually-recursive/foo/bundle.json
@@ -1,0 +1,1 @@
+{"deps":[{"local-path":"../bar","type":"local"}]}

--- a/stable/test/testdata/self-referential/bundle.json
+++ b/stable/test/testdata/self-referential/bundle.json
@@ -1,0 +1,1 @@
+{"deps":[{"local-path":".","type":"local"}]}


### PR DESCRIPTION
This PR addresses a TODO comment in Bundle.paths(), and also issue #96.
The `paths()` call will not recurse to process a path it has already seen. This includes the degenerate case where a local-dep is specified as `"."`.
