### PR TITLE
Remove unneeded curl install for CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,6 @@ jobs:
     docker:
       - image: ponylang/ponyc:release
     steps:
-      - run: apt-get update
-      - run: apt-get install -y curl
       - checkout
       - run: make test integration
       - zulip/status:
@@ -28,8 +26,6 @@ jobs:
     docker:
       - image: ponylang/changelog-tool:release
     steps:
-      - run: apt-get update
-      - run: apt-get install -y curl
       - checkout
       - run: changelog-tool verify CHANGELOG.md
       - zulip/status:


### PR DESCRIPTION
No longer needed now that the ponyc-ci:release image has been
updated to include curl.

Closes #115