### PR TITLE
Stop building AppImages on release

### DIFF
--- a/.bintray.bash
+++ b/.bintray.bash
@@ -38,13 +38,6 @@ case "$REPO_TYPE" in
       ],
     \"publish\": true"
     ;;
-  "appimage")
-    FILES="\"files\":
-      [
-        {\"includePattern\": \"/home/travis/build/ponylang/pony-stable/(.*.AppImage)\", \"uploadPattern\": \"\$1\"}
-      ],
-    \"publish\": true"
-    ;;
 esac
 
 JSON="{

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to the Pony compiler and standard library will be documented
 
 ### Changed
 
+- No longer release AppImage versions of pony-stable
 
 ## [0.2.1] - 2019-07-24
 


### PR DESCRIPTION
They aren't really used. Turning off as they are currently broken.