### PR TITLE
Only run changelog-bot against master

### DIFF
--- a/.github/workflows/changelog-bot.yml
+++ b/.github/workflows/changelog-bot.yml
@@ -2,6 +2,8 @@ name: Changelog Bot
 
 on:
   push:
+    branches:
+      - master
     paths-ignore:
       - CHANGELOG.md
 


### PR DESCRIPTION
Given our workflow, we never use it for anything other than PRs
that merge into master. Given that, running on pushes to other
branches is wasteful.

This commit turns off for anything that isn't master.