### PR TITLE
Fix Windows release when using new release process

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,7 +9,6 @@ branches:
 configuration:
   - release
 
-skip_tags: true
 skip_commits:
   files:
     - .gitattributes


### PR DESCRIPTION
Because `skip_tags` was set to true, we weren't starting a CI job
to do a release when a tag like `0.1.0` was pushed.

Removing `skip_tags` fixes the "no Windows release" problem encountered
during our most recent attempt at releasing.

Closes #128